### PR TITLE
Allow autocomplete to act on a specified key, rather than only 'tab'.

### DIFF
--- a/urwid_readline/readline_edit.py
+++ b/urwid_readline/readline_edit.py
@@ -74,6 +74,7 @@ class ReadlineEdit(urwid.Edit):
         )
         self._autocomplete_state = None
         self._autocomplete_func = None
+        self._autocomplete_key = None
         self._autocomplete_delims = " \t\n;"
         self._paste_buffer = PasteBuffer()
         self._undo_buffer = UndoBuffer()
@@ -81,7 +82,7 @@ class ReadlineEdit(urwid.Edit):
 
     def keypress(self, size, key):
         self.size = size
-        if key == "tab" and self._autocomplete_func:
+        if key == self._autocomplete_key and self._autocomplete_func:
             self._complete()
             return None
         else:
@@ -337,8 +338,9 @@ class ReadlineEdit(urwid.Edit):
         if self.multiline:
             self.insert_text("\n")
 
-    def enable_autocomplete(self, func):
+    def enable_autocomplete(self, func, key=None):
         self._autocomplete_func = func
+        self._autocomplete_key = key if key is not None else "tab"
         self._autocomplete_state = None
 
     def set_completer_delims(self, delimiters):

--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -436,7 +436,12 @@ def test_transpose(start_text, start_pos, end_text, end_pos):
         ),
     ],
 )
-def test_enable_autocomplete(start_text, start_pos, source, positions):
+@pytest.mark.parametrize("autocomplete_key", [None, "tab", "ctrl q"])
+def test_enable_autocomplete(
+    start_text, start_pos, source, positions, autocomplete_key
+):
+    keypress = autocomplete_key if autocomplete_key else "tab"
+
     def compl(text, state):
         tmp = (
             [c for c in source if c and c.startswith(text)] if text else source
@@ -447,10 +452,10 @@ def test_enable_autocomplete(start_text, start_pos, source, positions):
             return None
 
     edit = ReadlineEdit(edit_text=start_text, edit_pos=start_pos)
-    edit.enable_autocomplete(compl)
+    edit.enable_autocomplete(compl, key=autocomplete_key)
     for position in positions:
         expected_text, expected_pos = position
-        edit.keypress(None, "tab")
+        edit.keypress(None, keypress)
         assert edit.edit_text == expected_text
         assert edit.edit_pos == expected_pos
 


### PR DESCRIPTION
If tab is used for other things in application, it's useful to have the option of a specified key rather than a hardcoded one :)