### PR TITLE
Add feature to block keypress using `block_keypress` property.

### DIFF
--- a/urwid_readline/readline_edit.py
+++ b/urwid_readline/readline_edit.py
@@ -117,8 +117,11 @@ class ReadlineEdit(urwid.Edit):
                     "enter": self.insert_new_line,
                 }
             )
+        self.block_keypress = False
 
     def keypress(self, size, key):
+        if self.block_keypress:
+            return
         self.size = size
         if key == self._autocomplete_key and self._autocomplete_func:
             self._complete()

--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -517,3 +517,13 @@ def test_paste(paste_buffer, text, pos, expected_pos, expected_text):
     edit.paste()
     assert edit.edit_pos == expected_pos
     assert edit.edit_text == expected_text
+
+@pytest.mark.parametrize(
+    "block, start_text, start_pos, end_pos",
+    [(True, "ab", 2, 2), (False, "ab", 2, 1)],
+)
+def test_block_keypress(block, start_text, start_pos, end_pos):
+    edit = ReadlineEdit(edit_text=start_text, edit_pos=start_pos)
+    edit.block_keypress = block
+    edit.keypress(edit.size, 'left')
+    assert edit.edit_pos == end_pos


### PR DESCRIPTION
@rr- this will be useful for blocking inputs temporarily or permanently to some edit boxes.