### PR TITLE
Lower maintenance burden via dev setup & CI automation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,28 @@
+name: Linting & tests
+
+on: [push, pull_request]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Regular package install from checkout
+        run: pip install .
+      - name: Dev package install from checkout
+        run: pip install .[dev]
+      - name: Run tests with pytest
+        run: pytest 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Example how to use the program can be found in the
 [examples](https://github.com/rr-/urwid_readline/blob/master/example/)
 directory.
 
+### Development
+
+Please ensure pull requests pass CI, which requires your code to be formatted
+with `black .` and tests to pass via `pytest`.
+
+Both tools can be installed with the `dev` extra install option; such an
+install from a local git repo reflecting the code (ie. 'editable'), ideally in
+a python virtual environment, can be achieved through a command like
+`python3 -m pip install --editable .[dev]`.
+
 ### Features
 
 Supported operations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(
         "Topic :: Software Development :: Widget Sets",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    extras_require={
+        "dev": ["black", "pytest"],
+    },
 )

--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -509,7 +509,11 @@ def test_enable_autocomplete(
                 ("forward", "start", 5),
             ],
         ),
-        ("", 0, [("reverse", "next", 4), ("forward", "", 0)],),
+        (
+            "",
+            0,
+            [("reverse", "next", 4), ("forward", "", 0)],
+        ),
         (
             "st",
             2,
@@ -523,7 +527,11 @@ def test_enable_autocomplete(
 )
 @pytest.mark.parametrize(
     "autocomplete_key, autocomplete_key_reverse",
-    [(None, None), ("tab", "shift tab"), ("ctrl q", "ctrl m"),],
+    [
+        (None, None),
+        ("tab", "shift tab"),
+        ("ctrl q", "ctrl m"),
+    ],
 )
 def test_enable_autocomplete_reverse(
     start_text, start_pos, edits, autocomplete_key, autocomplete_key_reverse


### PR DESCRIPTION
The head of the repo doesn't appear to pass `black`, so this PR aims to address this and improve some other pain points:
* Fix the existing formatting using the current setup
* Add the standard configuration for black with the previously-indicated line-length preference
* Add an option to install a 'dev version', which will also install black and pytest (combined with previous change)
* Add a Travis setup to ensure the code is blackified and pytest succeeds.
* Update README.md with a note to ensure that CI should pass with black and 

This is dependent upon accepting and enabling Travis, but should reduce the need to ask contributors to make changes as frequently and automate ensuring contributions pass the black and pytest requirements.