### PR TITLE
Add tests for setting autocomplete delimiters & support no delimiters

### DIFF
--- a/urwid_readline/readline_edit.py
+++ b/urwid_readline/readline_edit.py
@@ -363,18 +363,31 @@ class ReadlineEdit(urwid.Edit):
             text_before_caret = self.edit_text[0 : self.edit_pos]
             text_after_caret = self.edit_text[self.edit_pos :]
 
-            group = re.escape(self._autocomplete_delims)
-            match = re.match(
-                "^(?P<prefix>.*[" + group + "])(?P<infix>.*?)$",
-                text_before_caret,
-                flags=re.M | re.DOTALL,
-            )
-            if match:
-                prefix = match.group("prefix")
-                infix = match.group("infix")
+            if self._autocomplete_delims:
+                group = re.escape(self._autocomplete_delims)
+                match = re.match(
+                    "^(?P<prefix>.*[" + group + "])(?P<infix>.*?)$",
+                    text_before_caret,
+                    flags=re.M | re.DOTALL,
+                )
+                if match:
+                    prefix = match.group("prefix")
+                    infix = match.group("infix")
+                else:
+                    prefix = ""
+                    infix = text_before_caret
             else:
+                match = re.match(
+                    "^(?P<infix>.*?)$",
+                    text_before_caret,
+                    flags=re.M | re.DOTALL,
+                )
                 prefix = ""
-                infix = text_before_caret
+                if match:
+                    infix = match.group("infix")
+                else:
+                    infix = text_before_caret
+
             suffix = text_after_caret
 
             self._autocomplete_state = AutocompleteState(

--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -610,6 +610,8 @@ def test_enable_autocomplete_clear_state(completion_func_for_source):
         (";", " ", "firstw secondw"),
         (";", ";", "firstw;firstw;secondw"),
         ("#", " ", "firstw secondw"),
+        ("", " ", "firstw secondw"),
+        ("", "-", "firstw-secondw"),
     ],
     ids=[
         "default:space/tab/newline/semicolon-space",
@@ -617,6 +619,8 @@ def test_enable_autocomplete_clear_state(completion_func_for_source):
         "custom:semicolon-space",
         "custom:semicolon-semicolon",
         "custom:hash-space",
+        "no delimiters-space",  # matches from start of text box
+        "no delimiters-hyphen",  # matches from start of text box
     ],
 )
 def test_autocomplete_delimiters(

--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -603,24 +603,31 @@ def test_enable_autocomplete_clear_state(completion_func_for_source):
 
 
 @pytest.mark.parametrize(
-    "delimiters, final_phrase",
+    "autocomplete_delimiters, word_separator, final_phrase",
     [
-        (None, "firstw firstw secondw"),
-        (";", "firstw secondw"),
+        (None, " ", "firstw firstw secondw"),
+        (None, ";", "firstw;firstw;secondw"),
+        (";", " ", "firstw secondw"),
+        (";", ";", "firstw;firstw;secondw"),
+        ("#", " ", "firstw secondw"),
     ],
     ids=[
-        "default:space/tab/newline/semicolon",
-        "custom:semicolon",
+        "default:space/tab/newline/semicolon-space",
+        "default:space/tab/newline/semicolon-semicolon",
+        "custom:semicolon-space",
+        "custom:semicolon-semicolon",
+        "custom:hash-space",
     ],
 )
 def test_autocomplete_delimiters(
     completion_func_for_source,
-    delimiters,
+    autocomplete_delimiters,
+    word_separator,
     final_phrase,
     word1="firstw",
     word2="secondw",
 ):
-    phrase = " ".join([word1, word2])
+    phrase = word_separator.join([word1, word2])
     phrase_length = len(phrase)
 
     source = [phrase]
@@ -629,8 +636,8 @@ def test_autocomplete_delimiters(
 
     edit = ReadlineEdit(edit_text=word1, edit_pos=len(word1))
     edit.enable_autocomplete(compl)
-    if delimiters is not None:
-        edit.set_completer_delims(delimiters)
+    if autocomplete_delimiters is not None:
+        edit.set_completer_delims(autocomplete_delimiters)
 
     # Completion from word1 to phrase
     edit.keypress(edit.size, "tab")
@@ -640,10 +647,10 @@ def test_autocomplete_delimiters(
     # Backspace to after word1 + space
     for _ in range(len(word2)):
         edit.keypress(edit.size, "backspace")
-    assert edit.edit_text == word1 + " "
+    assert edit.edit_text == word1 + word_separator
     assert edit.edit_pos == len(word1) + 1
 
-    # Completion from word1 + space
+    # Completion from word1 + word_separator
     edit.keypress(edit.size, "tab")
     assert edit.edit_text == final_phrase
     assert edit.edit_pos == len(final_phrase)


### PR DESCRIPTION
On exploring a fix for #13, I saw there was already a `set_autocomplete_delims`.

After an initial refactor of the common `compl` function into a factory fixture, this PR adds tests for the above method, initially with parametrization demonstrating how the problem observed in zulip-terminal can be resolved (or at least worked around), then expanding it to illustrate behavior when the autocomplete list contains phrases with word separators which are not a space - at this point simply expanding test coverage.

The last commit(s) extend the functionality and test cases to allow setting the autocomplete delimters to be an empty string, ie. no characters - this essentially allows any character in the autocomplete phrases, but matches all text from the start of the text box.

**Note that I've left the the last two commits separate for now, but these can squashed before merging.**
(currently this emphasizes that the existing code is broken when passed an empty string)