### PR TITLE
Add support for limit_chars argument for ReadlineEdit.

### DIFF
--- a/urwid_readline/test_readline_edit.py
+++ b/urwid_readline/test_readline_edit.py
@@ -682,12 +682,36 @@ def test_undo(keys, expected_edit_pos, expected_text):
 
 
 @pytest.mark.parametrize(
-    "paste_buffer, text, pos, expected_pos, expected_text",
-    [(["OO"], "F", 1, 3, "FOO"), (["BOO", "FOO"], "", 0, 3, "FOO")],
+    "paste_buffer, text, max_char, pos, expected_pos, expected_text",
+    [
+        (["OO"], "F", None, 1, 3, "FOO"),
+        (["BOO", "FOO"], "", None, 0, 3, "FOO"),
+        (["BCDE"], "A", 3, 1, 3, "ABC"),
+        (["FOO", "BOO", "FOOBAR"], "", 3, 0, 3, "FOO"),
+        (["FOOBAR"], "BAR", 3, 0, 0, "BAR"),
+    ],
 )
-def test_paste(paste_buffer, text, pos, expected_pos, expected_text):
-    edit = ReadlineEdit(edit_text=text, edit_pos=pos)
+def test_paste(paste_buffer, text, max_char, pos, expected_pos, expected_text):
+    edit = ReadlineEdit(edit_text=text, max_char=max_char, edit_pos=pos)
     edit._paste_buffer[:] = paste_buffer
     edit.paste()
+    assert edit.edit_pos == expected_pos
+    assert edit.edit_text == expected_text
+
+
+@pytest.mark.parametrize(
+    "text, key, max_char, pos, expected_pos, expected_text",
+    [
+        ("FOAA", "S", None, 4, 5, "FOAAS"),
+        ("FOOBAR", "A", 3, 3, 3, "FOO"),
+        ("OO", "F", 3, 0, 1, "FOO"),
+        ("ABCDE", "F", 4, 3, 3, "ABCD"),
+    ],
+)
+def test_insert_char_at_cursor(
+    text, key, max_char, pos, expected_pos, expected_text
+):
+    edit = ReadlineEdit(edit_text=text, max_char=max_char, edit_pos=pos)
+    edit._insert_char_at_cursor(key)
     assert edit.edit_pos == expected_pos
     assert edit.edit_text == expected_text


### PR DESCRIPTION
There may be several use-cases, where you want to restrict the user input into a `ReadlineEdit` widget to not go beyond a particular limit, this PR makes it possible for clients to specify a `max_char` argument when initializing a `ReadlineEdit` widget so that the user can't input text beyond that limit.
In particular `zulip-terminal` has such a use-case, where it needs `ReadlineEdit` widgets for stream and topic to only accept input up to 60 characters.

**Relevant discussion**:
- [general/restricted topic length](https://chat.zulip.org/#narrow/stream/2-general/topic/restricted.20topic.20length)
- [zulip terminal/restrict topic name length](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/restrict.20topic.20name.20length)