### PR TITLE
Use up to date versions in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: psf/black@stable
 
-  pytest:
+  pytest-base:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,3 +26,32 @@ jobs:
         run: pip install .[dev]
       - name: Run tests with pytest
         run: pytest 
+
+  pytest-other-platforms:
+    needs:
+      - black
+      - pytest-base
+    strategy:
+      # Not failing fast allows all matrix jobs to try & finish even if one fails early
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Regular package install from checkout
+        run: pip install .
+      - name: Dev package install from checkout
+        run: pip install .[dev]
+      - name: Run tests with pytest
+        run: pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,16 +6,16 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: psf/black@stable
 
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.6
       - name: Upgrade pip

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Regular package install from checkout


### PR DESCRIPTION
This bumps the version of GitHub actions used in CI, as well as the python version used for running tests to a supported version. The latter means that pytest now runs correctly; prior to this PR it is failing.

The last commit adds a matrix to run pytest on different python versions. I'm not sure if this is likely to bring up specific issues, and you may prefer testing on different OS's instead or in addition - which we do in zulip-terminal. I've set a dependency from the black and test checks on python 3.8, before doing the other versions, since that avoids unnecessarily running on all versions if one fails, but they could easily be run in parallel too if that works out better.